### PR TITLE
Use term instead of title

### DIFF
--- a/src/main/kotlin/FyydClient.kt
+++ b/src/main/kotlin/FyydClient.kt
@@ -36,8 +36,8 @@ class FyydClient @JvmOverloads constructor(
         service = retrofit.create(FyydService::class.java)
     }
 
-    fun searchPodcasts(title: String, limit: Int? = null): Single<FyydResponse> {
-        return service.searchPodcasts(title, limit)
+    fun searchPodcasts(term: String, limit: Int? = null): Single<FyydResponse> {
+        return service.searchPodcasts(term, limit)
     }
 
 }

--- a/src/main/kotlin/FyydService.kt
+++ b/src/main/kotlin/FyydService.kt
@@ -7,7 +7,7 @@ import retrofit2.http.Query
 interface FyydService {
 
     @GET("search/podcast")
-    fun searchPodcasts(@Query("title") title: String,
+    fun searchPodcasts(@Query("term") term: String,
                        @Query("count") limit: Int?): Single<FyydResponse>
 
 


### PR DESCRIPTION
The fyyd developer told me that using `term` probably gives better results than `title`. He implemented a workaround for AntennaPod on the server side but this is the proper way to do it.